### PR TITLE
(maint) Add version format check and exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+/target

--- a/src/clj_semver/core.clj
+++ b/src/clj_semver/core.clj
@@ -26,11 +26,19 @@
        (or (nil? (:build v))
            (string? (:build v)))))
 
+(defn valid-format?
+  "Checks the string `s` for semantic versioning formatting"
+  [s]
+  (let [response (re-matches pattern s)]
+    (when (nil? response)
+      (throw (new IllegalArgumentException "Not a valid version format")))
+    response))
+
 (defn parse
   "Parses string `s` into a version map"
   [s]
   {:pre  [(string? s)
-          (re-matches pattern s)]
+          (valid-format? s)]
    :post [(valid? %)]}
   (let [[[_ major minor patch pre-release build]] (re-seq pattern s)]
     {:major (try-parse-int major)

--- a/test/clj_semver/test/core.clj
+++ b/test/clj_semver/test/core.clj
@@ -22,9 +22,9 @@
          {:major 1 :minor 2 :patch 3 :pre-release "alpha" :build "build.1"}))
   (is (= (parse "1.2.3+alpha-build.1")
          {:major 1 :minor 2 :patch 3 :pre-release nil :build "alpha-build.1"}))
-  (is (thrown? AssertionError (parse "1.2.3-alpha!@.12")))
-  (is (thrown? AssertionError (parse "1.2")))
-  (is (thrown? AssertionError (parse "1.a.3+aewf-123"))))
+  (is (thrown? IllegalArgumentException (parse "1.2.3-alpha!@.12")))
+  (is (thrown? IllegalArgumentException (parse "1.2")))
+  (is (thrown? IllegalArgumentException (parse "1.a.3+aewf-123"))))
 
 (deftest comparison
   ;; These are taken from the semver spec


### PR DESCRIPTION
Prior to this commit if version info did not match the desired pattern
and AssertionError was raised. This commit adds a function that tries to
match the version info with the a priori pattern and raises an exception
if the syntax is improperly formatted that can be caught downstream.
Also changes the tests to check for the new IllegalArgumentException's.
