### PR TITLE
(maint) Add invalid version number to error msg

### DIFF
--- a/src/clj_semver/core.clj
+++ b/src/clj_semver/core.clj
@@ -31,7 +31,7 @@
   [s]
   (let [response (re-matches pattern s)]
     (when (nil? response)
-      (throw (new IllegalArgumentException (str s  "is not a valid semantic version number"))))
+      (throw (new IllegalArgumentException (format "%s is not a valid semantic version number" s))))
     response))
 
 (defn parse


### PR DESCRIPTION
Prior to this commit the error message for invalid versions did not
return the version number. This commit adds the invalid version number
to the message.
