### PR TITLE
Change validation function (valid-format?) to boolean test.

### DIFF
--- a/src/clj_semver/core.clj
+++ b/src/clj_semver/core.clj
@@ -29,10 +29,7 @@
 (defn valid-format?
   "Checks the string `s` for semantic versioning formatting"
   [s]
-  (let [response (re-matches pattern s)]
-    (when (nil? response)
-      (throw (new IllegalArgumentException (format "%s is not a valid semantic version number" s))))
-    response))
+  (if (nil? (re-matches pattern s)) false true))
 
 (defn parse
   "Parses string `s` into a version map"

--- a/test/clj_semver/test/core.clj
+++ b/test/clj_semver/test/core.clj
@@ -22,9 +22,9 @@
          {:major 1 :minor 2 :patch 3 :pre-release "alpha" :build "build.1"}))
   (is (= (parse "1.2.3+alpha-build.1")
          {:major 1 :minor 2 :patch 3 :pre-release nil :build "alpha-build.1"}))
-  (is (thrown? IllegalArgumentException (parse "1.2.3-alpha!@.12")))
-  (is (thrown? IllegalArgumentException (parse "1.2")))
-  (is (thrown? IllegalArgumentException (parse "1.a.3+aewf-123"))))
+  (is (thrown? AssertionError (parse "1.2.3-alpha!@.12")))
+  (is (thrown? AssertionError (parse "1.2")))
+  (is (thrown? AssertionError (parse "1.a.3+aewf-123"))))
 
 (deftest comparison
   ;; These are taken from the semver spec


### PR DESCRIPTION
Prior to this commit, (valid-format?) threw an
InvalidArgumentException when run on an invalid semver.
This commit changes this validation test to return false in
this case and changes the corresponding (parse) unit tests
to check for AssertionErrors.
